### PR TITLE
disable exported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,8 @@ if (OpenEXR_FOUND)
 endif()
 
 # Add all targets to the build-tree export set
-export( TARGETS IlmCtl IlmCtlMath IlmCtlSimd Iex IlmThread Half FILE "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" )
+# FIXME export targets properly to fix cmake errors
+# export( TARGETS IlmCtl IlmCtlMath IlmCtlSimd FILE "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" )
 export( PACKAGE CTL )
 
 # Create a CTLBuildTreeSettings.cmake file for the use from the build tree
@@ -101,6 +102,7 @@ install( FILES
   "${PROJECT_BINARY_DIR}/CTLConfig.cmake"
   "${PROJECT_BINARY_DIR}/CTLConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
-install(FILES "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" DESTINATION
-  "${INSTALL_CMAKE_DIR}" COMPONENT dev)
+
+# FIXME use new cmake syntax
+#install(FILES "${PROJECT_BINARY_DIR}/CTLLibraryDepends.cmake" DESTINATION "${INSTALL_CMAKE_DIR}" COMPONENT dev)
 


### PR DESCRIPTION
# What this PR does?

* disable targets export cmake warns about

# Why it does that?

* packaging needs to be refactored to support modern cmake versions